### PR TITLE
Add graphviz output for distributed plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "0.1.0"
+source = "git+https://github.com/datafusion-contrib/datafusion-distributed?branch=main#f921a87ee311f190345f5443c3e57b273cc1ce71"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-distributed?branch=main#bad700d5dad1f0b62554bfe3d91acc464db00ccc"
+source = "git+https://github.com/datafusion-contrib/datafusion-distributed?branch=robtandy%2Fbetter_graphviz_plans#f2a284435690e8a24734efca60a3168f6e4e1db3"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -629,7 +629,7 @@ checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
  "num-traits",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8e18d0dca9578507f13f9803add0df13362b02c501c1c17734f0dbb52eaf0b"
+checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
 dependencies = [
  "unicode-segmentation",
  "unicode-width",
@@ -1034,7 +1034,6 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-distributed?branch=robtandy%2Fbetter_graphviz_plans#f2a284435690e8a24734efca60a3168f6e4e1db3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -1698,7 +1697,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.4+wasi-0.2.4",
+ "wasi 0.14.6+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1840,9 +1839,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1882,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1903,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2285,12 +2284,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -2569,7 +2562,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2953,15 +2946,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9621e389a110cae094269936383d69b869492f03e5c1ed2d575a53c029d4441d"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.61.0",
 ]
 
@@ -2994,9 +2986,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "seq-macro"
@@ -3006,18 +2998,28 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.224"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3026,24 +3028,26 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3267,15 +3271,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3572,9 +3576,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3710,9 +3714,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.4+wasi-0.2.4"
+version = "0.14.6+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+checksum = "7f71243a3f320c00a8459e455c046ce571229c2f31fd11645d9dc095e3068ca0"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
@@ -3820,13 +3833,13 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
@@ -3855,32 +3868,26 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -3889,7 +3896,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3898,16 +3905,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3916,7 +3914,7 @@ version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -3925,31 +3923,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3959,22 +3940,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3983,22 +3952,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4007,22 +3964,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4031,28 +3976,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 # Documentation: https://docs.rs/vercel_runtime/latest/vercel_runtime
 vercel_runtime = { version = "1.1.4" }
 datafusion = { version = "49.0.0" }
-datafusion-distributed = { git = "https://github.com/datafusion-contrib/datafusion-distributed", branch = "main" }
+datafusion-distributed = { git = "https://github.com/datafusion-contrib/datafusion-distributed", branch = "robtandy/better_graphviz_plans" }
 serde = { version = "1.0.203", features = ["derive"] }
 futures = "0.3.31"
 url = "2.5.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 # Documentation: https://docs.rs/vercel_runtime/latest/vercel_runtime
 vercel_runtime = { version = "1.1.4" }
 datafusion = { version = "49.0.0" }
-datafusion-distributed = { git = "https://github.com/datafusion-contrib/datafusion-distributed", branch = "robtandy/better_graphviz_plans" }
+datafusion-distributed = { git = "https://github.com/datafusion-contrib/datafusion-distributed", branch = "main" }
 serde = { version = "1.0.203", features = ["derive"] }
 futures = "0.3.31"
 url = "2.5.7"

--- a/api/main.rs
+++ b/api/main.rs
@@ -7,7 +7,7 @@ use datafusion::execution::SessionStateBuilder;
 use datafusion::physical_plan::{displayable, execute_stream, ExecutionPlan};
 use datafusion::prelude::{ParquetReadOptions, SessionConfig, SessionContext};
 use datafusion_distributed::{
-    display_stage_graphviz, ArrowFlightEndpoint, BoxCloneSyncChannel, ChannelResolver,
+    display_plan_graphviz, ArrowFlightEndpoint, BoxCloneSyncChannel, ChannelResolver,
     DistributedExt, DistributedPhysicalOptimizerRule, DistributedSessionBuilderContext,
 };
 use futures::TryStreamExt;
@@ -241,11 +241,8 @@ async fn execute_statements(
 
     let physical_plan_str =
         display_physical_plan(&physical_plan).unwrap_or_else(|err| err.to_string());
-    let graphviz_str = if distributed {
-        display_graphviz_plan(&physical_plan).unwrap_or_else(|err| err.to_string())
-    } else {
-        "".to_owned()
-    };
+    let graphviz_str = 
+        display_graphviz_plan(&physical_plan).unwrap_or_else(|err| err.to_string());
 
     Ok(SqlResult {
         columns,
@@ -266,7 +263,7 @@ fn display_physical_plan(physical_plan: &Arc<dyn ExecutionPlan>) -> Result<Strin
 }
 
 fn display_graphviz_plan(physical_plan: &Arc<dyn ExecutionPlan>) -> Result<String, Error> {
-    let graphviz_plan_str = display_stage_graphviz(physical_plan.clone())?;
+    let graphviz_plan_str = display_plan_graphviz(physical_plan.clone())?;
     Ok(graphviz_plan_str)
 }
 

--- a/api/main.rs
+++ b/api/main.rs
@@ -7,8 +7,8 @@ use datafusion::execution::SessionStateBuilder;
 use datafusion::physical_plan::{displayable, execute_stream, ExecutionPlan};
 use datafusion::prelude::{ParquetReadOptions, SessionConfig, SessionContext};
 use datafusion_distributed::{
-    ArrowFlightEndpoint, BoxCloneSyncChannel, ChannelResolver, DistributedExt,
-    DistributedPhysicalOptimizerRule, DistributedSessionBuilderContext,
+    display_stage_graphviz, ArrowFlightEndpoint, BoxCloneSyncChannel, ChannelResolver,
+    DistributedExt, DistributedPhysicalOptimizerRule, DistributedSessionBuilderContext,
 };
 use futures::TryStreamExt;
 use hyper_util::rt::TokioIo;
@@ -152,6 +152,7 @@ struct SqlResult {
     rows: Vec<Vec<String>>,
     logical_plan: String,
     physical_plan: String,
+    graphviz_plan: String,
 }
 
 async fn execute_statements(
@@ -164,11 +165,26 @@ async fn execute_statements(
 
     let mut builder = SessionStateBuilder::new()
         .with_default_features()
-        .with_config(cfg);
+        .with_config(cfg.clone());
     if distributed {
+        let mut cfg = cfg.with_target_partitions(4); // 4 partitions such that we have concurrency
+                                                     // but not too many partitions to make understanding
+                                                     // distributed plans challenging
+
+        // Disable single partition joins to better showcase distributed plans
+        cfg = cfg.set_str(
+            "datafusion.optimizer.hash_join_single_partition_threshold",
+            "0",
+        );
+        cfg = cfg.set_str(
+            "datafusion.optimizer.hash_join_single_partition_threshold.rows",
+            "0",
+        );
+
         builder = builder
+            .with_config(cfg)
             .with_physical_optimizer_rule(Arc::new(
-                DistributedPhysicalOptimizerRule::default().with_maximum_partitions_per_task(1),
+                DistributedPhysicalOptimizerRule::default().with_maximum_partitions_per_task(2),
             ))
             .with_distributed_channel_resolver(CHANNEL_RESOLVER.clone());
     }
@@ -222,11 +238,20 @@ async fn execute_statements(
         rows.push(vec!["...".to_string(); columns.len()]);
     }
 
+    let physical_plan_str =
+        display_physical_plan(&physical_plan).unwrap_or_else(|err| err.to_string());
+    let graphviz_plan_str = if distributed {
+        display_graphviz_plan(&physical_plan).unwrap_or_else(|err| err.to_string())
+    } else {
+        "".to_owned()
+    };
+
     Ok(SqlResult {
         columns,
         rows,
         logical_plan: logical_plan_str,
-        physical_plan: display_physical_plan(&physical_plan).unwrap_or_else(|err| err.to_string()),
+        physical_plan: physical_plan_str,
+        graphviz_plan: graphviz_plan_str,
     })
 }
 
@@ -236,6 +261,11 @@ fn display_physical_plan(physical_plan: &Arc<dyn ExecutionPlan>) -> Result<Strin
     let curr_dir = curr_dir.trim_start_matches("/");
     let physical_plan_str = physical_plan_str.replace(curr_dir, "");
     Ok(physical_plan_str)
+}
+
+fn display_graphviz_plan(physical_plan: &Arc<dyn ExecutionPlan>) -> Result<String, Error> {
+    let graphviz_plan_str = display_stage_graphviz(physical_plan.clone())?;
+    Ok(graphviz_plan_str)
 }
 
 async fn load_parquet_files(base: String, ctx: &SessionContext) -> Result<(), DataFusionError> {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@viz-js/viz": "^3.17.0",
     "monaco-editor": "^0.52.2",
     "monaco-sql-languages": "^0.15.1",
     "monaco-vim": "^0.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      '@viz-js/viz':
+        specifier: ^3.17.0
+        version: 3.17.0
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
@@ -1015,6 +1018,9 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+
+  '@viz-js/viz@3.17.0':
+    resolution: {integrity: sha512-oft6Hub0dRPXQcsx0oUMYTmTgU3RM9QVcr23/mrDUvcPeiHijEFNQxpigH8h399xLURoq6RrC9fYpYGEoqqIIA==}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -3433,6 +3439,8 @@ snapshots:
       vite: 5.4.19(@types/node@24.0.5)(lightningcss@1.30.1)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@viz-js/viz@3.17.0': {}
 
   abbrev@3.0.1: {}
 

--- a/src/ResultVisualizer.tsx
+++ b/src/ResultVisualizer.tsx
@@ -69,10 +69,16 @@ const SqlResponseVisualizer = React.memo(
             Physical Plan
           </Tabs.Trigger>
           <Tabs.Trigger
+            value="graphviz_svg"
+            className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
+          >
+            Graphviz Physical Plan SVG
+          </Tabs.Trigger>
+          <Tabs.Trigger
             value="graphviz"
             className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
           >
-            Graphviz Physical Plan
+            Graphviz Physical Plan DOT
           </Tabs.Trigger>
         </Tabs.List>
 
@@ -154,8 +160,19 @@ const SqlResponseVisualizer = React.memo(
             {result.physical_plan}
           </SyntaxHighlighter>
         </Tabs.Content>
+        <Tabs.Content
+          value="graphviz_svg"
+          className="flex-1 overflow-auto px-2"
+        >
+          <div dangerouslySetInnerHTML={{ __html: result.graphviz_svg }} />
+        </Tabs.Content>
         <Tabs.Content value="graphviz" className="flex-1 overflow-auto px-2">
-          <div dangerouslySetInnerHTML={{ __html: result.graphviz_plan }} />
+          <span
+            className="text-text-secondary"
+            style={{ whiteSpace: "pre-wrap" }}
+          >
+            {result.graphviz}
+          </span>
         </Tabs.Content>
       </Tabs.Root>
     );

--- a/src/ResultVisualizer.tsx
+++ b/src/ResultVisualizer.tsx
@@ -1,9 +1,9 @@
-import 'react-tooltip/dist/react-tooltip.css'
-import React, { HTMLProps } from 'react';
-import { Tooltip } from 'react-tooltip'
-import * as Tabs from '@radix-ui/react-tabs';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import "react-tooltip/dist/react-tooltip.css";
+import React, { HTMLProps } from "react";
+import { Tooltip } from "react-tooltip";
+import * as Tabs from "@radix-ui/react-tabs";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { ApiState, SqlResponse } from "@/src/useApi";
 import { useLocalStorage } from "@/src/useLocalStorage";
@@ -12,122 +12,152 @@ export interface ResultVisualizerProps extends HTMLProps<HTMLDivElement> {
   state: ApiState;
 }
 
-export function ResultVisualizer ({ state, className = '', ...rest }: ResultVisualizerProps) {
-  if (state.type === 'nothing') return null;
+export function ResultVisualizer({
+  state,
+  className = "",
+  ...rest
+}: ResultVisualizerProps) {
+  if (state.type === "nothing") return null;
 
   return (
     <div className={`${className} relative`} {...rest}>
-      <Tooltip id="cell-tooltip" delayShow={500}/>
+      <Tooltip id="cell-tooltip" delayShow={500} />
       <div className="h-full overflow-auto -mt-0.5">
-        {state.type === 'loading' && (
-          <LoadingSpinner/>
-        )}
-        {state.type === 'error' && (
+        {state.type === "loading" && <LoadingSpinner />}
+        {state.type === "error" && (
           <div className="flex items-center justify-center h-full text-text-error text-center text-xl mx-12">
             {state.message}
           </div>
         )}
-        {state.type === 'result' && <SqlResponseVisualizer result={state.result}/>}
+        {state.type === "result" && (
+          <SqlResponseVisualizer result={state.result} />
+        )}
       </div>
     </div>
   );
 }
 
-const SqlResponseVisualizer = React.memo(({ result }: { result: SqlResponse }) => {
-  const [selectedTab, setSelectedTab] =  useLocalStorage('result-tab', 'table')
+const SqlResponseVisualizer = React.memo(
+  ({ result }: { result: SqlResponse }) => {
+    const [selectedTab, setSelectedTab] = useLocalStorage(
+      "result-tab",
+      "table",
+    );
+    return (
+      <Tabs.Root
+        value={selectedTab}
+        onValueChange={setSelectedTab}
+        className="h-full flex flex-col"
+      >
+        <Tabs.List className="flex bg-primary-surface border-b border-border mb-2">
+          <Tabs.Trigger
+            value="table"
+            className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
+          >
+            Table
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="logical"
+            className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
+          >
+            Logical Plan
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="physical"
+            className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
+          >
+            Physical Plan
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="graphviz"
+            className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
+          >
+            Graphviz Physical Plan
+          </Tabs.Trigger>
+        </Tabs.List>
 
-  return (
-    <Tabs.Root value={selectedTab} onValueChange={setSelectedTab} className="h-full flex flex-col">
-      <Tabs.List className="flex bg-primary-surface border-b border-border mb-2">
-        <Tabs.Trigger
-          value="table"
-          className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
-        >
-          Table
-        </Tabs.Trigger>
-        <Tabs.Trigger
-          value="logical"
-          className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
-        >
-          Logical Plan
-        </Tabs.Trigger>
-        <Tabs.Trigger
-          value="physical"
-          className="px-4 py-2 font-medium text-sm border-b-2 border-transparent text-text-secondary hover:text-text-primary hover:bg-secondary-surface transition-colors data-[state=active]:border-accent data-[state=active]:text-text-primary data-[state=active]:bg-secondary-surface cursor-pointer"
-        >
-          Physical Plan
-        </Tabs.Trigger>
-      </Tabs.List>
-
-      <Tabs.Content value="table" className="flex-1 overflow-auto">
-        <table className="table-auto w-full text-text-primary">
-          <thead>
-          <tr>
-            {result.columns.map(([name, type], index) => (
-              <th key={index}
-                  className="px-4 py-2 bg-primary-surface text-left whitespace-nowrap overflow-hidden text-overflow-ellipsis">
-                {name} ({type})
-              </th>
-            ))}
-          </tr>
-          </thead>
-          <tbody>
-          {result.rows.map((row, rowIndex) => (
-            <tr key={rowIndex} className={rowIndex % 2 === 0 ? 'bg-secondary-surface' : 'bg-primary-surface'}>
-              {row.map((cell, cellIndex) => (
-                <td
-                  key={cellIndex}
-                  className="px-4 py-2 whitespace-nowrap overflow-hidden text-overflow-ellipsis"
+        <Tabs.Content value="table" className="flex-1 overflow-auto">
+          <table className="table-auto w-full text-text-primary">
+            <thead>
+              <tr>
+                {result.columns.map(([name, type], index) => (
+                  <th
+                    key={index}
+                    className="px-4 py-2 bg-primary-surface text-left whitespace-nowrap overflow-hidden text-overflow-ellipsis"
+                  >
+                    {name} ({type})
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {result.rows.map((row, rowIndex) => (
+                <tr
+                  key={rowIndex}
+                  className={
+                    rowIndex % 2 === 0
+                      ? "bg-secondary-surface"
+                      : "bg-primary-surface"
+                  }
                 >
-                  {cell.split('\n').map((line, index, arr) => (
-                    <React.Fragment key={index}>
-                            <span
-                              data-tooltip-id="cell-tooltip"
-                              data-tooltip-content={line}
-                              style={{ whiteSpace: 'pre-wrap' }}
-                            >
-                              {line}
-                            </span>
-                      {index < arr.length - 1 && <br/>}
-                    </React.Fragment>
+                  {row.map((cell, cellIndex) => (
+                    <td
+                      key={cellIndex}
+                      className="px-4 py-2 whitespace-nowrap overflow-hidden text-overflow-ellipsis"
+                    >
+                      {cell.split("\n").map((line, index, arr) => (
+                        <React.Fragment key={index}>
+                          <span
+                            data-tooltip-id="cell-tooltip"
+                            data-tooltip-content={line}
+                            style={{ whiteSpace: "pre-wrap" }}
+                          >
+                            {line}
+                          </span>
+                          {index < arr.length - 1 && <br />}
+                        </React.Fragment>
+                      ))}
+                    </td>
                   ))}
-                </td>
+                </tr>
               ))}
-            </tr>
-          ))}
-          </tbody>
-        </table>
-      </Tabs.Content>
-      
-      <Tabs.Content value="logical" className="flex-1 overflow-auto px-2">
-        <SyntaxHighlighter
-          language="rust"
-          style={oneDark}
-          customStyle={{
-            border: '1px solid var(--color-border)',
-            borderRadius: '6px',
-            fontSize: '14px',
-            margin: 0,
-          }}
-        >
-          {result.logical_plan}
-        </SyntaxHighlighter>
-      </Tabs.Content>
-      
-      <Tabs.Content value="physical" className="flex-1 overflow-auto px-2">
-        <SyntaxHighlighter
-          language="rust"
-          style={oneDark}
-          customStyle={{
-            border: '1px solid var(--color-border)',
-            borderRadius: '6px',
-            fontSize: '14px',
-            margin: 0,
-          }}
-        >
-          {result.physical_plan}
-        </SyntaxHighlighter>
-      </Tabs.Content>
-    </Tabs.Root>
-  )
-})
+            </tbody>
+          </table>
+        </Tabs.Content>
+
+        <Tabs.Content value="logical" className="flex-1 overflow-auto px-2">
+          <SyntaxHighlighter
+            language="rust"
+            style={oneDark}
+            customStyle={{
+              border: "1px solid var(--color-border)",
+              borderRadius: "6px",
+              fontSize: "14px",
+              margin: 0,
+            }}
+          >
+            {result.logical_plan}
+          </SyntaxHighlighter>
+        </Tabs.Content>
+
+        <Tabs.Content value="physical" className="flex-1 overflow-auto px-2">
+          <SyntaxHighlighter
+            language="rust"
+            style={oneDark}
+            customStyle={{
+              border: "1px solid var(--color-border)",
+              borderRadius: "6px",
+              fontSize: "14px",
+              margin: 0,
+            }}
+          >
+            {result.physical_plan}
+          </SyntaxHighlighter>
+        </Tabs.Content>
+        <Tabs.Content value="graphviz" className="flex-1 overflow-auto px-2">
+          <div dangerouslySetInnerHTML={{ __html: result.graphviz_plan }} />
+        </Tabs.Content>
+      </Tabs.Root>
+    );
+  },
+);

--- a/src/useApi.ts
+++ b/src/useApi.ts
@@ -1,65 +1,87 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
+import * as Viz from "@viz-js/viz";
 
 export interface SqlRequest {
-  stmts: string[]
-  distributed: boolean
+  stmts: string[];
+  distributed: boolean;
 }
 
 export interface SqlResponse {
-  columns: Array<[string, string]>,
-  rows: Array<Array<string>>,
-  logical_plan: string
-  physical_plan: string
+  columns: Array<[string, string]>;
+  rows: Array<Array<string>>;
+  logical_plan: string;
+  physical_plan: string;
+  graphviz_plan: string;
 }
 
-export async function executeStatements (stmts: string[], distributed: boolean): Promise<SqlResponse> {
+export async function executeStatements(
+  stmts: string[],
+  distributed: boolean,
+): Promise<SqlResponse> {
   const req: SqlRequest = {
     stmts,
-    distributed
-  }
-  const res = await fetch(
-    '/api/main',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req),
-    }
-  )
+    distributed,
+  };
+  const res = await fetch("/api/main", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(req),
+  });
   if (res.status === 200) {
-    return await res.json()
+    return await res.json();
   } else if (res.status === 400) {
-    const { message } = await res.json()
-    throw new Error(message)
+    const { message } = await res.json();
+    throw new Error(message);
   } else {
-    const msg = await res.text()
-    throw new Error(`unexpected status ${res.status}: ${msg}`)
+    const msg = await res.text();
+    throw new Error(`unexpected status ${res.status}: ${msg}`);
   }
 }
 
 export type ApiState =
-  { type: 'nothing' } |
-  { type: 'loading' } |
-  { type: 'error', message: string } |
-  { type: 'result', result: SqlResponse }
+  | { type: "nothing" }
+  | { type: "loading" }
+  | { type: "error"; message: string }
+  | { type: "result"; result: SqlResponse };
 
 export interface ApiRequest {
-  statement: string
-  distributed: boolean
+  statement: string;
+  distributed: boolean;
 }
 
-export function useApi () {
-  const [state, setState] = useState<ApiState>({ type: 'nothing' });
+export function useApi() {
+  const [state, setState] = useState<ApiState>({ type: "nothing" });
 
   const execute = React.useCallback(async (req: ApiRequest) => {
-    setState({ type: 'loading' });
-    const result = await executeStatements(
-      req.statement.split(';').map(_ => _.trim()).filter(_ => _.length > 0),
-      req.distributed
-    )
-      .then((result) => ({ type: 'result' as const, result }))
-      .catch((err) => ({ type: 'error' as const, message: err.toString() }));
-    setState(result)
-    return result
+    setState({ type: "loading" });
+    try {
+      const result = await executeStatements(
+        req.statement
+          .split(";")
+          .map((_) => _.trim())
+          .filter((_) => _.length > 0),
+        req.distributed,
+      );
+
+      if (result.graphviz_plan.length > 0) {
+        const viz = await Viz.instance();
+        try {
+          const graphviz_plan = viz.renderSVGElement(result.graphviz_plan);
+          console.log("graphviz_plan", graphviz_plan);
+          result.graphviz_plan = graphviz_plan.outerHTML;
+        } catch (e) {
+          console.error("failed to render graphviz plan", e);
+        }
+      }
+      setState({ type: "result", result });
+      return {
+        type: "result" as const,
+        result,
+      };
+    } catch (error) {
+      const err = error as Error;
+      return { type: "error" as const, message: err.toString() };
+    }
   }, []);
 
   return { state, execute };

--- a/src/useApi.ts
+++ b/src/useApi.ts
@@ -11,7 +11,8 @@ export interface SqlResponse {
   rows: Array<Array<string>>;
   logical_plan: string;
   physical_plan: string;
-  graphviz_plan: string;
+  graphviz_svg: string;
+  graphviz: string;
 }
 
 export async function executeStatements(
@@ -63,12 +64,11 @@ export function useApi() {
         req.distributed,
       );
 
-      if (result.graphviz_plan.length > 0) {
+      if (result.graphviz.length > 0) {
         const viz = await Viz.instance();
         try {
-          const graphviz_plan = viz.renderSVGElement(result.graphviz_plan);
-          console.log("graphviz_plan", graphviz_plan);
-          result.graphviz_plan = graphviz_plan.outerHTML;
+          const svg = viz.renderSVGElement(result.graphviz);
+          result.graphviz_svg = svg.outerHTML;
         } catch (e) {
           console.error("failed to render graphviz plan", e);
         }


### PR DESCRIPTION
Graphviz output added for distributed plans using https://viz-js.com/

In order to provide illustrative plans:
- num partitions set to 4
- maximum partitions per task set to 2
- single partition join threshold config setting set to 0 rows and bytes to force partitioned hash joins to demonstrate the distributed nature.  Otherwise the small tables will result in trivial plans


We can follow up on changing the branch when the graphviz PR is merged in to the distributed-datafusion project